### PR TITLE
tdc: allow setting software motion limit

### DIFF
--- a/thorlabs_tcube/test_thorlabs_tcube.py
+++ b/thorlabs_tcube/test_thorlabs_tcube.py
@@ -52,7 +52,7 @@ class GenericTdcTest:
         self.assertEqual(test_vector, self.cont.get_home_parameters())
 
     def test_limit_switch_parameters(self):
-        test_vector = 2, 1
+        test_vector = 2, 1, 55, 56, 0x1
         self.cont.set_limit_switch_parameters(*test_vector)
         self.assertEqual(test_vector, self.cont.get_limit_switch_parameters())
 


### PR DESCRIPTION
tested with kdc101 and z825b that position limit is indeed in
encoder counts and uses same conversion as everything else,
contrary to current version of thorlabs documentation
(dated 26 May 2021)

----------------------------------

NB: at nist we use the "Tdc001" class interchangeably for TDC001/KDC101/KST101 as most of the API is the same. That's definitely a hack but the alternative is to try to make sense of the introduction that says which functions apply to which controllers specifically, which isn't worth anyone's time over just duck typing it. This PR will break anyone's code using `get_limit_switch_parameters` as the size of the return tuple is changed, but I think the user base for this is small.